### PR TITLE
feat:add iam role annotation to eks autoscaler service account

### DIFF
--- a/cluster-autoscaler-aws/components/cluster-autoscaler-aws/application.yaml
+++ b/cluster-autoscaler-aws/components/cluster-autoscaler-aws/application.yaml
@@ -19,6 +19,12 @@ spec:
           clusterName: <CLUSTER_NAME>
         awsRegion: <CLOUD_REGION>
         cloudProvider: aws
+        rbac:
+          serviceAccount:
+            annotations: 
+              eks.amazonaws.com/role-arn : arn:aws:iam::<AWS_ACCOUNT_ID>:role/cluster-autoscaler-<CLUSTER_NAME>
+            create: true
+            name: "cluster-autoscaler"
   destination:
     name: <CLUSTER_DESTINATION>
     namespace: kube-system

--- a/cluster-autoscaler-aws/components/cluster-autoscaler-aws/application.yaml
+++ b/cluster-autoscaler-aws/components/cluster-autoscaler-aws/application.yaml
@@ -21,7 +21,7 @@ spec:
         cloudProvider: aws
         rbac:
           serviceAccount:
-            annotations: 
+            annotations:
               eks.amazonaws.com/role-arn : arn:aws:iam::<AWS_ACCOUNT_ID>:role/cluster-autoscaler-<CLUSTER_NAME>
             create: true
             name: "cluster-autoscaler"


### PR DESCRIPTION
## Description
We added the irsa for cluster autoscaler in gitops-template,we need to annotate the service account created with that arn.we added for both mgmt and workload cluster module.

## Testing 
Add this to registry or directly run kubectl for application.yaml in the respective cluster
We tested it and its working  :)