### PR TITLE
fix: flappy k-ray repository url

### DIFF
--- a/flappy-kray/components/flappy-kray/application.yaml
+++ b/flappy-kray/components/flappy-kray/application.yaml
@@ -19,7 +19,7 @@ spec:
     helm:
       values: |
         image:
-          repository: public.ecr.aws/kubefirst/flappy-kray
+          repository: ghcr.io/konstructio/flappy-kray
         ingress:
           enabled: false
   project: <PROJECT>


### PR DESCRIPTION
## Description
Flappy kray images were moved to ghrc https://github.com/konstructio/flappy-kray/actions/runs/11404334184/job/31733272154#step:5:183
