### PR TITLE
kubernetes-dashboard to user nginx and cert-manager

### DIFF
--- a/kubernetes-dashboard/components/kubernetes-dashboard/application.yaml
+++ b/kubernetes-dashboard/components/kubernetes-dashboard/application.yaml
@@ -37,26 +37,26 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
- annotations:
-   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-   cert-manager.io/cluster-issuer: letsencrypt-prod
-   argocd.argoproj.io/sync-wave: '1'
- name: kubernetes-dashboard
- namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    argocd.argoproj.io/sync-wave: '1'
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
 spec:
- ingressClassName: nginx
- rules:
-   - host: kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
-     http:
-       paths:
-         - backend:
-             service:
-               name: <CLUSTER_NAME>-kubernetes-dashboard-kong-proxy
-               port:
-                 number: 443
-           path: /
-           pathType: Prefix
- tls:
-   - hosts:
-       - kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
-     secretName: kubernetes-dashboard-tls
+  ingressClassName: nginx
+  rules:
+    - host: kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
+      http:
+        paths:
+          - backend:
+              service:
+                name: <CLUSTER_NAME>-kubernetes-dashboard-kong-proxy
+                port:
+                  number: 443
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
+      secretName: kubernetes-dashboard-tls

--- a/kubernetes-dashboard/components/kubernetes-dashboard/application.yaml
+++ b/kubernetes-dashboard/components/kubernetes-dashboard/application.yaml
@@ -34,29 +34,29 @@ spec:
     syncOptions:
       - CreateNamespace=true
 ---
- apiVersion: networking.k8s.io/v1
- kind: Ingress
- metadata:
-   annotations:
-     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-     cert-manager.io/cluster-issuer: letsencrypt-prod
-     argocd.argoproj.io/sync-wave: '1'
-   name: kubernetes-dashboard
-   namespace: kubernetes-dashboard
- spec:
-   ingressClassName: nginx
-   rules:
-     - host: kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
-       http:
-         paths:
-           - backend:
-               service:
-                 name: <CLUSTER_NAME>-kubernetes-dashboard-kong-proxy
-                 port:
-                   number: 443
-             path: /
-             pathType: Prefix
-   tls:
-     - hosts:
-         - kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
-       secretName: kubernetes-dashboard-tls
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+ annotations:
+   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+   cert-manager.io/cluster-issuer: letsencrypt-prod
+   argocd.argoproj.io/sync-wave: '1'
+ name: kubernetes-dashboard
+ namespace: kubernetes-dashboard
+spec:
+ ingressClassName: nginx
+ rules:
+   - host: kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
+     http:
+       paths:
+         - backend:
+             service:
+               name: <CLUSTER_NAME>-kubernetes-dashboard-kong-proxy
+               port:
+                 number: 443
+           path: /
+           pathType: Prefix
+ tls:
+   - hosts:
+       - kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
+     secretName: kubernetes-dashboard-tls

--- a/kubernetes-dashboard/components/kubernetes-dashboard/application.yaml
+++ b/kubernetes-dashboard/components/kubernetes-dashboard/application.yaml
@@ -13,7 +13,7 @@ spec:
   project: <PROJECT>
   sources:
     - repoURL: "https://kubernetes.github.io/dashboard"
-      targetRevision: 7.9.0
+      targetRevision: 7.12.0
       chart: kubernetes-dashboard
       helm:
         valueFiles:
@@ -33,3 +33,30 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+---
+ apiVersion: networking.k8s.io/v1
+ kind: Ingress
+ metadata:
+   annotations:
+     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+     cert-manager.io/cluster-issuer: letsencrypt-prod
+     argocd.argoproj.io/sync-wave: '1'
+   name: kubernetes-dashboard
+   namespace: kubernetes-dashboard
+ spec:
+   ingressClassName: nginx
+   rules:
+     - host: kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
+       http:
+         paths:
+           - backend:
+               service:
+                 name: <CLUSTER_NAME>-kubernetes-dashboard-kong-proxy
+                 port:
+                   number: 443
+             path: /
+             pathType: Prefix
+   tls:
+     - hosts:
+         - kubernetes-dashboard-<CLUSTER_NAME>.<DOMAIN_NAME>
+       secretName: kubernetes-dashboard-tls

--- a/kubernetes-dashboard/components/kubernetes-dashboard/values.yaml
+++ b/kubernetes-dashboard/components/kubernetes-dashboard/values.yaml
@@ -1,21 +1,4 @@
 ---
 app:
   ingress:
-    enabled: true
-    hosts:
-      - kubernetes-dashboard.<CLUSTER_NAME>.<DOMAIN_NAME>
-    ingressClassName: nginx
-    tls:
-      enabled: true
-      secretName: "kubernetes-dashboard-tls"
-    # Adds following annotation cert-manager.io/cluster-issuer: letsencrypt-prod
-    issuer:
-      scope: cluster
-      name: "letsencrypt-prod"
-    # This will append our Ingress with annotations required by our default configuration.
-    #    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    #    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    #    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    useDefaultAnnotations: true
-    annotations:
-      argocd.argoproj.io/sync-wave: "2"
+    enabled: false


### PR DESCRIPTION
## Description
stops using the default kong ingress and leverages our platform's ingress-nginx and cert-manager with letsencrypt-prod